### PR TITLE
Add bookmark tags

### DIFF
--- a/src/main/java/mesfavoris/internal/extensions/DefaultBookmarkTypeExtension.java
+++ b/src/main/java/mesfavoris/internal/extensions/DefaultBookmarkTypeExtension.java
@@ -2,10 +2,12 @@ package mesfavoris.internal.extensions;
 
 import mesfavoris.extensions.AbstractBookmarkTypeExtension;
 import mesfavoris.internal.ui.details.CommentBookmarkDetailPart;
+import mesfavoris.internal.ui.details.TagsBookmarkDetailPart;
 import mesfavoris.internal.ui.details.BookmarkPropertiesDetailPart;
 import mesfavoris.internal.ui.details.MarkerBookmarkDetailPart;
 import mesfavoris.internal.mcp.McpBookmarkProperties;
 import mesfavoris.model.Bookmark;
+import mesfavoris.tags.TagsBookmarkProperties;
 import mesfavoris.ui.renderers.BookmarkFolderLabelProvider;
 
 import static mesfavoris.bookmarktype.BookmarkPropertyDescriptor.BookmarkPropertyType.INSTANT;
@@ -47,10 +49,17 @@ public class DefaultBookmarkTypeExtension extends AbstractBookmarkTypeExtension 
                 .updatable(false)
                 .build());
 
+        addProperty(bookmarkPropertyDescriptor(TagsBookmarkProperties.PROP_TAGS)
+                .type(STRING)
+                .updatable(true)
+                .description("Comma-separated list of tags for the bookmark, e.g. \"bug,perf\". Tag names cannot contain commas.")
+                .build());
+
         addLabelProvider(new BookmarkFolderLabelProvider());
 
         // Add detail part providers
         addDetailPartProvider(CommentBookmarkDetailPart::new);
+        addDetailPartProvider(TagsBookmarkDetailPart::new);
         addDetailPartProvider(BookmarkPropertiesDetailPart::new);
         addDetailPartProvider(MarkerBookmarkDetailPart::new);
 

--- a/src/main/java/mesfavoris/internal/search/BookmarksSearchEverywhereContributor.java
+++ b/src/main/java/mesfavoris/internal/search/BookmarksSearchEverywhereContributor.java
@@ -15,6 +15,7 @@ import mesfavoris.model.BookmarkDatabase;
 import mesfavoris.model.BookmarkFolder;
 import mesfavoris.model.BookmarksTree;
 import mesfavoris.service.IBookmarksService;
+import mesfavoris.tags.Tags;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -139,13 +140,24 @@ public class BookmarksSearchEverywhereContributor implements SearchEverywhereCon
     }
 
     private boolean matchesSearchText(@NotNull Bookmark bookmark, @NotNull String searchText) {
+        // explicit tag query (tag:xxx or #xxx) matches only against tags
+        String tagTerm = Tags.extractTagQuery(searchText);
+        if (tagTerm != null) {
+            return Tags.hasTagMatching(bookmark, tagTerm);
+        }
+
         String name = bookmark.getPropertyValue(Bookmark.PROPERTY_NAME);
         if (name != null && name.toLowerCase().contains(searchText)) {
             return true;
         }
 
         String comment = bookmark.getPropertyValue(Bookmark.PROPERTY_COMMENT);
-        return comment != null && comment.toLowerCase().contains(searchText);
+        if (comment != null && comment.toLowerCase().contains(searchText)) {
+            return true;
+        }
+
+        // free text also matches tags
+        return Tags.hasTagMatching(bookmark, searchText);
     }
 
     @NotNull

--- a/src/main/java/mesfavoris/internal/tags/TagVirtualFolder.java
+++ b/src/main/java/mesfavoris/internal/tags/TagVirtualFolder.java
@@ -1,0 +1,58 @@
+package mesfavoris.internal.tags;
+
+import mesfavoris.internal.ui.virtual.BookmarkLink;
+import mesfavoris.internal.ui.virtual.VirtualBookmarkFolder;
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarkDatabase;
+import mesfavoris.model.BookmarkFolder;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.BookmarksTree;
+import mesfavoris.tags.Tags;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Virtual folder listing every leaf bookmark carrying a given tag. Instances are created and refreshed by
+ * {@link TagsRootVirtualFolder}, which owns the database listening; this folder therefore does not listen
+ * on its own.
+ */
+public class TagVirtualFolder extends VirtualBookmarkFolder {
+	private final BookmarkDatabase bookmarkDatabase;
+	private final String tag;
+
+	public TagVirtualFolder(BookmarkId parentId, BookmarkDatabase bookmarkDatabase, String tag) {
+		super(parentId, tag);
+		this.bookmarkDatabase = bookmarkDatabase;
+		this.tag = tag;
+	}
+
+	public String getTag() {
+		return tag;
+	}
+
+	@Override
+	public List<BookmarkLink> getChildren() {
+		BookmarksTree bookmarksTree = bookmarkDatabase.getBookmarksTree();
+		List<BookmarkLink> links = new ArrayList<>();
+		for (Bookmark bookmark : bookmarksTree) {
+			if (bookmark instanceof BookmarkFolder) {
+				continue;
+			}
+			if (Tags.getTags(bookmark).stream().anyMatch(t -> t.equalsIgnoreCase(tag))) {
+				links.add(new BookmarkLink(bookmarkFolder.getId(), bookmark));
+			}
+		}
+		return links;
+	}
+
+	@Override
+	protected void initListening() {
+		// no-op: refresh is driven by the owning TagsRootVirtualFolder
+	}
+
+	@Override
+	protected void stopListening() {
+		// no-op
+	}
+}

--- a/src/main/java/mesfavoris/internal/tags/TagVirtualFolder.java
+++ b/src/main/java/mesfavoris/internal/tags/TagVirtualFolder.java
@@ -7,7 +7,6 @@ import mesfavoris.model.BookmarkDatabase;
 import mesfavoris.model.BookmarkFolder;
 import mesfavoris.model.BookmarkId;
 import mesfavoris.model.BookmarksTree;
-import mesfavoris.tags.Tags;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,11 +18,13 @@ import java.util.List;
  */
 public class TagVirtualFolder extends VirtualBookmarkFolder {
 	private final BookmarkDatabase bookmarkDatabase;
+	private final TagsIndex tagsIndex;
 	private final String tag;
 
-	public TagVirtualFolder(BookmarkId parentId, BookmarkDatabase bookmarkDatabase, String tag) {
+	public TagVirtualFolder(BookmarkId parentId, BookmarkDatabase bookmarkDatabase, TagsIndex tagsIndex, String tag) {
 		super(parentId, tag);
 		this.bookmarkDatabase = bookmarkDatabase;
+		this.tagsIndex = tagsIndex;
 		this.tag = tag;
 	}
 
@@ -35,13 +36,12 @@ public class TagVirtualFolder extends VirtualBookmarkFolder {
 	public List<BookmarkLink> getChildren() {
 		BookmarksTree bookmarksTree = bookmarkDatabase.getBookmarksTree();
 		List<BookmarkLink> links = new ArrayList<>();
-		for (Bookmark bookmark : bookmarksTree) {
-			if (bookmark instanceof BookmarkFolder) {
+		for (BookmarkId bookmarkId : tagsIndex.getBookmarkIds(tag)) {
+			Bookmark bookmark = bookmarksTree.getBookmark(bookmarkId);
+			if (bookmark == null || bookmark instanceof BookmarkFolder) {
 				continue;
 			}
-			if (Tags.getTags(bookmark).stream().anyMatch(t -> t.equalsIgnoreCase(tag))) {
-				links.add(new BookmarkLink(bookmarkFolder.getId(), bookmark));
-			}
+			links.add(new BookmarkLink(bookmarkFolder.getId(), bookmark));
 		}
 		return links;
 	}

--- a/src/main/java/mesfavoris/internal/tags/TagsIndex.java
+++ b/src/main/java/mesfavoris/internal/tags/TagsIndex.java
@@ -1,0 +1,181 @@
+package mesfavoris.internal.tags;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
+import mesfavoris.internal.model.merge.BookmarksTreeIterable;
+import mesfavoris.internal.model.merge.BookmarksTreeIterator.Algorithm;
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarkDatabase;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.IBookmarksListener;
+import mesfavoris.model.modification.BookmarkDeletedModification;
+import mesfavoris.model.modification.BookmarkPropertiesModification;
+import mesfavoris.model.modification.BookmarksAddedModification;
+import mesfavoris.model.modification.BookmarksModification;
+import mesfavoris.service.IBookmarksService;
+import mesfavoris.tags.Tags;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+
+/**
+ * Project-level incremental index of bookmark tags. Instead of scanning the whole tree on every query, it
+ * maintains {@code tag -> bookmark ids} in memory and updates it from {@link BookmarksModification} events,
+ * so tag lookups stay cheap even with many thousands of bookmarks.
+ *
+ * <p>The index is built lazily on first access (a single O(N) pass) and then kept in sync. Updates are
+ * idempotent per bookmark, so re-delivering or overlapping events cannot corrupt the counts.
+ */
+@Service(Service.Level.PROJECT)
+public final class TagsIndex implements IBookmarksListener, Disposable {
+	private final BookmarkDatabase bookmarkDatabase;
+	// lowercase tag -> display form (first seen)
+	private final Map<String, String> displayByLowerTag = new HashMap<>();
+	// lowercase tag -> ids of bookmarks carrying it
+	private final Map<String, Set<BookmarkId>> idsByLowerTag = new HashMap<>();
+	// bookmark id -> lowercase tags it currently carries (the index's own view, for idempotent updates)
+	private final Map<BookmarkId, Set<String>> lowerTagsByBookmark = new HashMap<>();
+	private boolean initialized = false;
+
+	@SuppressWarnings("unused") // instantiated by the platform as a project service
+	public TagsIndex(@NotNull Project project) {
+		this(project.getService(IBookmarksService.class).getBookmarkDatabase());
+	}
+
+	public TagsIndex(@NotNull BookmarkDatabase bookmarkDatabase) {
+		this.bookmarkDatabase = bookmarkDatabase;
+		bookmarkDatabase.addListener(this);
+	}
+
+	public static TagsIndex getInstance(@NotNull Project project) {
+		return project.getService(TagsIndex.class);
+	}
+
+	/**
+	 * Returns every distinct tag in use across the tree (display form), ordered case-insensitively.
+	 */
+	public synchronized SortedSet<String> getAllTags() {
+		ensureInitialized();
+		SortedSet<String> tags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+		tags.addAll(displayByLowerTag.values());
+		return tags;
+	}
+
+	/**
+	 * Returns the ids of the bookmarks carrying the given tag (case-insensitive).
+	 */
+	public synchronized Set<BookmarkId> getBookmarkIds(String tag) {
+		ensureInitialized();
+		if (tag == null) {
+			return Set.of();
+		}
+		Set<BookmarkId> ids = idsByLowerTag.get(tag.trim().toLowerCase());
+		return ids == null ? Set.of() : new HashSet<>(ids);
+	}
+
+	private void ensureInitialized() {
+		if (initialized) {
+			return;
+		}
+		for (Bookmark bookmark : bookmarkDatabase.getBookmarksTree()) {
+			reindexBookmark(bookmark.getId(), Tags.getTags(bookmark));
+		}
+		initialized = true;
+	}
+
+	@Override
+	public synchronized void bookmarksModified(List<BookmarksModification> modifications) {
+		if (!initialized) {
+			// events before the first read are captured by the initial build
+			return;
+		}
+		for (BookmarksModification modification : modifications) {
+			if (modification instanceof BookmarkPropertiesModification propertiesModification) {
+				if (touchesTags(propertiesModification)) {
+					Bookmark bookmark = propertiesModification.getTargetTree().getBookmark(propertiesModification.getBookmarkId());
+					reindexBookmark(propertiesModification.getBookmarkId(), bookmark == null ? List.of() : Tags.getTags(bookmark));
+				}
+			} else if (modification instanceof BookmarksAddedModification addedModification) {
+				for (Bookmark added : addedModification.getBookmarks()) {
+					for (Bookmark bookmark : new BookmarksTreeIterable(addedModification.getTargetTree(), added.getId(), Algorithm.PRE_ORDER)) {
+						reindexBookmark(bookmark.getId(), Tags.getTags(bookmark));
+					}
+				}
+			} else if (modification instanceof BookmarkDeletedModification deletedModification) {
+				for (Bookmark deleted : deletedModification.getDeletedBookmarks()) {
+					reindexBookmark(deleted.getId(), List.of());
+				}
+			}
+			// BookmarksMovedModification does not change tags
+		}
+	}
+
+	private boolean touchesTags(BookmarkPropertiesModification modification) {
+		return modification.getAddedProperties().contains(PROP_TAGS)
+				|| modification.getModifiedProperties().contains(PROP_TAGS)
+				|| modification.getDeletedProperties().contains(PROP_TAGS);
+	}
+
+	/**
+	 * Sets the tags of a bookmark in the index to exactly {@code newTags}. Idempotent: calling it again with
+	 * the same tags is a no-op.
+	 */
+	private void reindexBookmark(BookmarkId bookmarkId, List<String> newTags) {
+		Set<String> newLowerTags = new HashSet<>();
+		Map<String, String> displayByLower = new HashMap<>();
+		for (String tag : newTags) {
+			String lower = tag.toLowerCase();
+			if (newLowerTags.add(lower)) {
+				displayByLower.put(lower, tag);
+			}
+		}
+
+		Set<String> oldLowerTags = lowerTagsByBookmark.getOrDefault(bookmarkId, Set.of());
+		for (String lower : oldLowerTags) {
+			if (!newLowerTags.contains(lower)) {
+				removeAssignment(lower, bookmarkId);
+			}
+		}
+		for (String lower : newLowerTags) {
+			if (!oldLowerTags.contains(lower)) {
+				addAssignment(lower, displayByLower.get(lower), bookmarkId);
+			}
+		}
+
+		if (newLowerTags.isEmpty()) {
+			lowerTagsByBookmark.remove(bookmarkId);
+		} else {
+			lowerTagsByBookmark.put(bookmarkId, newLowerTags);
+		}
+	}
+
+	private void addAssignment(String lowerTag, String displayTag, BookmarkId bookmarkId) {
+		idsByLowerTag.computeIfAbsent(lowerTag, k -> new HashSet<>()).add(bookmarkId);
+		displayByLowerTag.putIfAbsent(lowerTag, displayTag);
+	}
+
+	private void removeAssignment(String lowerTag, BookmarkId bookmarkId) {
+		Set<BookmarkId> ids = idsByLowerTag.get(lowerTag);
+		if (ids != null) {
+			ids.remove(bookmarkId);
+			if (ids.isEmpty()) {
+				idsByLowerTag.remove(lowerTag);
+				displayByLowerTag.remove(lowerTag);
+			}
+		}
+	}
+
+	@Override
+	public void dispose() {
+		bookmarkDatabase.removeListener(this);
+	}
+}

--- a/src/main/java/mesfavoris/internal/tags/TagsIndex.java
+++ b/src/main/java/mesfavoris/internal/tags/TagsIndex.java
@@ -38,12 +38,10 @@ import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
 @Service(Service.Level.PROJECT)
 public final class TagsIndex implements IBookmarksListener, Disposable {
 	private final BookmarkDatabase bookmarkDatabase;
-	// lowercase tag -> display form (first seen)
-	private final Map<String, String> displayByLowerTag = new HashMap<>();
-	// lowercase tag -> ids of bookmarks carrying it
-	private final Map<String, Set<BookmarkId>> idsByLowerTag = new HashMap<>();
-	// bookmark id -> lowercase tags it currently carries (the index's own view, for idempotent updates)
-	private final Map<BookmarkId, Set<String>> lowerTagsByBookmark = new HashMap<>();
+	// tag -> ids of bookmarks carrying it (tags are lower case, see Tags)
+	private final Map<String, Set<BookmarkId>> idsByTag = new HashMap<>();
+	// bookmark id -> tags it currently carries (the index's own view, for idempotent updates)
+	private final Map<BookmarkId, Set<String>> tagsByBookmark = new HashMap<>();
 	private boolean initialized = false;
 
 	@SuppressWarnings("unused") // instantiated by the platform as a project service
@@ -65,9 +63,7 @@ public final class TagsIndex implements IBookmarksListener, Disposable {
 	 */
 	public synchronized SortedSet<String> getAllTags() {
 		ensureInitialized();
-		SortedSet<String> tags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-		tags.addAll(displayByLowerTag.values());
-		return tags;
+		return new TreeSet<>(idsByTag.keySet());
 	}
 
 	/**
@@ -78,7 +74,7 @@ public final class TagsIndex implements IBookmarksListener, Disposable {
 		if (tag == null) {
 			return Set.of();
 		}
-		Set<BookmarkId> ids = idsByLowerTag.get(tag.trim().toLowerCase());
+		Set<BookmarkId> ids = idsByTag.get(tag.trim().toLowerCase());
 		return ids == null ? Set.of() : new HashSet<>(ids);
 	}
 
@@ -130,46 +126,36 @@ public final class TagsIndex implements IBookmarksListener, Disposable {
 	 * the same tags is a no-op.
 	 */
 	private void reindexBookmark(BookmarkId bookmarkId, List<String> newTags) {
-		Set<String> newLowerTags = new HashSet<>();
-		Map<String, String> displayByLower = new HashMap<>();
-		for (String tag : newTags) {
-			String lower = tag.toLowerCase();
-			if (newLowerTags.add(lower)) {
-				displayByLower.put(lower, tag);
+		Set<String> newTagSet = new HashSet<>(newTags);
+		Set<String> oldTagSet = tagsByBookmark.getOrDefault(bookmarkId, Set.of());
+		for (String tag : oldTagSet) {
+			if (!newTagSet.contains(tag)) {
+				removeAssignment(tag, bookmarkId);
+			}
+		}
+		for (String tag : newTagSet) {
+			if (!oldTagSet.contains(tag)) {
+				addAssignment(tag, bookmarkId);
 			}
 		}
 
-		Set<String> oldLowerTags = lowerTagsByBookmark.getOrDefault(bookmarkId, Set.of());
-		for (String lower : oldLowerTags) {
-			if (!newLowerTags.contains(lower)) {
-				removeAssignment(lower, bookmarkId);
-			}
-		}
-		for (String lower : newLowerTags) {
-			if (!oldLowerTags.contains(lower)) {
-				addAssignment(lower, displayByLower.get(lower), bookmarkId);
-			}
-		}
-
-		if (newLowerTags.isEmpty()) {
-			lowerTagsByBookmark.remove(bookmarkId);
+		if (newTagSet.isEmpty()) {
+			tagsByBookmark.remove(bookmarkId);
 		} else {
-			lowerTagsByBookmark.put(bookmarkId, newLowerTags);
+			tagsByBookmark.put(bookmarkId, newTagSet);
 		}
 	}
 
-	private void addAssignment(String lowerTag, String displayTag, BookmarkId bookmarkId) {
-		idsByLowerTag.computeIfAbsent(lowerTag, k -> new HashSet<>()).add(bookmarkId);
-		displayByLowerTag.putIfAbsent(lowerTag, displayTag);
+	private void addAssignment(String tag, BookmarkId bookmarkId) {
+		idsByTag.computeIfAbsent(tag, k -> new HashSet<>()).add(bookmarkId);
 	}
 
-	private void removeAssignment(String lowerTag, BookmarkId bookmarkId) {
-		Set<BookmarkId> ids = idsByLowerTag.get(lowerTag);
+	private void removeAssignment(String tag, BookmarkId bookmarkId) {
+		Set<BookmarkId> ids = idsByTag.get(tag);
 		if (ids != null) {
 			ids.remove(bookmarkId);
 			if (ids.isEmpty()) {
-				idsByLowerTag.remove(lowerTag);
-				displayByLowerTag.remove(lowerTag);
+				idsByTag.remove(tag);
 			}
 		}
 	}

--- a/src/main/java/mesfavoris/internal/tags/TagsRootVirtualFolder.java
+++ b/src/main/java/mesfavoris/internal/tags/TagsRootVirtualFolder.java
@@ -5,7 +5,6 @@ import mesfavoris.internal.ui.virtual.VirtualBookmarkFolder;
 import mesfavoris.model.BookmarkDatabase;
 import mesfavoris.model.BookmarkId;
 import mesfavoris.model.IBookmarksListener;
-import mesfavoris.tags.Tags;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -20,13 +19,15 @@ import java.util.SortedSet;
  */
 public class TagsRootVirtualFolder extends VirtualBookmarkFolder {
 	private final BookmarkDatabase bookmarkDatabase;
+	private final TagsIndex tagsIndex;
 	// reuse TagVirtualFolder instances across refreshes to keep tree node identity/expansion stable
 	private final Map<String, TagVirtualFolder> tagFolders = new LinkedHashMap<>();
 	private final IBookmarksListener bookmarksListener = modifications -> fireChildrenChanged();
 
-	public TagsRootVirtualFolder(BookmarkDatabase bookmarkDatabase, BookmarkId parentId) {
+	public TagsRootVirtualFolder(BookmarkDatabase bookmarkDatabase, TagsIndex tagsIndex, BookmarkId parentId) {
 		super(parentId, "Tags");
 		this.bookmarkDatabase = bookmarkDatabase;
+		this.tagsIndex = tagsIndex;
 	}
 
 	@Override
@@ -37,13 +38,13 @@ public class TagsRootVirtualFolder extends VirtualBookmarkFolder {
 
 	@Override
 	public synchronized List<VirtualBookmarkFolder> getChildFolders() {
-		SortedSet<String> tags = Tags.collectAllTags(bookmarkDatabase.getBookmarksTree());
+		SortedSet<String> tags = tagsIndex.getAllTags();
 		// drop folders for tags that no longer exist (tags is case-insensitive)
 		tagFolders.keySet().removeIf(tag -> !tags.contains(tag));
 		List<VirtualBookmarkFolder> result = new ArrayList<>();
 		for (String tag : tags) {
 			result.add(tagFolders.computeIfAbsent(tag,
-					t -> new TagVirtualFolder(bookmarkFolder.getId(), bookmarkDatabase, t)));
+					t -> new TagVirtualFolder(bookmarkFolder.getId(), bookmarkDatabase, tagsIndex, t)));
 		}
 		return result;
 	}

--- a/src/main/java/mesfavoris/internal/tags/TagsRootVirtualFolder.java
+++ b/src/main/java/mesfavoris/internal/tags/TagsRootVirtualFolder.java
@@ -1,0 +1,60 @@
+package mesfavoris.internal.tags;
+
+import mesfavoris.internal.ui.virtual.BookmarkLink;
+import mesfavoris.internal.ui.virtual.VirtualBookmarkFolder;
+import mesfavoris.model.BookmarkDatabase;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.IBookmarksListener;
+import mesfavoris.tags.Tags;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+/**
+ * Root virtual folder grouping bookmarks by tag: it exposes one {@link TagVirtualFolder} per tag currently
+ * in use across the tree. It listens to the bookmark database and refreshes the whole tags subtree whenever
+ * bookmarks change (the set of tags or their membership may have changed).
+ */
+public class TagsRootVirtualFolder extends VirtualBookmarkFolder {
+	private final BookmarkDatabase bookmarkDatabase;
+	// reuse TagVirtualFolder instances across refreshes to keep tree node identity/expansion stable
+	private final Map<String, TagVirtualFolder> tagFolders = new LinkedHashMap<>();
+	private final IBookmarksListener bookmarksListener = modifications -> fireChildrenChanged();
+
+	public TagsRootVirtualFolder(BookmarkDatabase bookmarkDatabase, BookmarkId parentId) {
+		super(parentId, "Tags");
+		this.bookmarkDatabase = bookmarkDatabase;
+	}
+
+	@Override
+	public List<BookmarkLink> getChildren() {
+		// no direct bookmarks; children are the per-tag sub-folders
+		return List.of();
+	}
+
+	@Override
+	public synchronized List<VirtualBookmarkFolder> getChildFolders() {
+		SortedSet<String> tags = Tags.collectAllTags(bookmarkDatabase.getBookmarksTree());
+		// drop folders for tags that no longer exist (tags is case-insensitive)
+		tagFolders.keySet().removeIf(tag -> !tags.contains(tag));
+		List<VirtualBookmarkFolder> result = new ArrayList<>();
+		for (String tag : tags) {
+			result.add(tagFolders.computeIfAbsent(tag,
+					t -> new TagVirtualFolder(bookmarkFolder.getId(), bookmarkDatabase, t)));
+		}
+		return result;
+	}
+
+	@Override
+	protected void initListening() {
+		bookmarkDatabase.addListener(bookmarksListener);
+	}
+
+	@Override
+	protected void stopListening() {
+		bookmarkDatabase.removeListener(bookmarksListener);
+	}
+}

--- a/src/main/java/mesfavoris/internal/toolwindow/MesFavorisPanel.java
+++ b/src/main/java/mesfavoris/internal/toolwindow/MesFavorisPanel.java
@@ -13,6 +13,7 @@ import com.intellij.util.ui.JBUI;
 import mesfavoris.internal.actions.RemoteStoreActionGroup;
 import mesfavoris.internal.markers.BookmarkWithMarkerLabelProvider;
 import mesfavoris.internal.recent.RecentBookmarksVirtualFolder;
+import mesfavoris.internal.tags.TagsRootVirtualFolder;
 import mesfavoris.internal.toolwindow.search.BookmarksTreeFilter;
 import mesfavoris.internal.toolwindow.search.SearchBookmarksTextField;
 import mesfavoris.internal.ui.details.BookmarkDetailsPart;
@@ -67,9 +68,10 @@ public class MesFavorisPanel extends JPanel implements DataProvider, Disposable 
                 bookmarkDatabase, visitedBookmarksProvider, rootId, 20);
         MostVisitedBookmarksVirtualFolder mostVisitedBookmarksVirtualFolder = new MostVisitedBookmarksVirtualFolder(project,
                 bookmarkDatabase, visitedBookmarksProvider, rootId, 20);
+        TagsRootVirtualFolder tagsRootVirtualFolder = new TagsRootVirtualFolder(bookmarkDatabase, rootId);
 
         tree = new BookmarksTreeComponent(bookmarkDatabase, treeFilter, List.of(recentBookmarksVirtualFolder,
-                latestVisitedBookmarksVirtualFolder, mostVisitedBookmarksVirtualFolder),this);
+                latestVisitedBookmarksVirtualFolder, mostVisitedBookmarksVirtualFolder, tagsRootVirtualFolder),this);
         BookmarksTreeCellRenderer bookmarksTreeCellRenderer = new BookmarksTreeCellRenderer(project, bookmarkDatabase,
                 project.getService(RemoteBookmarksStoreManager.class),
                 bookmarksService.getBookmarksDirtyStateTracker(),

--- a/src/main/java/mesfavoris/internal/toolwindow/MesFavorisPanel.java
+++ b/src/main/java/mesfavoris/internal/toolwindow/MesFavorisPanel.java
@@ -13,6 +13,7 @@ import com.intellij.util.ui.JBUI;
 import mesfavoris.internal.actions.RemoteStoreActionGroup;
 import mesfavoris.internal.markers.BookmarkWithMarkerLabelProvider;
 import mesfavoris.internal.recent.RecentBookmarksVirtualFolder;
+import mesfavoris.internal.tags.TagsIndex;
 import mesfavoris.internal.tags.TagsRootVirtualFolder;
 import mesfavoris.internal.toolwindow.search.BookmarksTreeFilter;
 import mesfavoris.internal.toolwindow.search.SearchBookmarksTextField;
@@ -68,7 +69,8 @@ public class MesFavorisPanel extends JPanel implements DataProvider, Disposable 
                 bookmarkDatabase, visitedBookmarksProvider, rootId, 20);
         MostVisitedBookmarksVirtualFolder mostVisitedBookmarksVirtualFolder = new MostVisitedBookmarksVirtualFolder(project,
                 bookmarkDatabase, visitedBookmarksProvider, rootId, 20);
-        TagsRootVirtualFolder tagsRootVirtualFolder = new TagsRootVirtualFolder(bookmarkDatabase, rootId);
+        TagsRootVirtualFolder tagsRootVirtualFolder = new TagsRootVirtualFolder(bookmarkDatabase,
+                TagsIndex.getInstance(project), rootId);
 
         tree = new BookmarksTreeComponent(bookmarkDatabase, treeFilter, List.of(recentBookmarksVirtualFolder,
                 latestVisitedBookmarksVirtualFolder, mostVisitedBookmarksVirtualFolder, tagsRootVirtualFolder),this);

--- a/src/main/java/mesfavoris/internal/toolwindow/search/BookmarksTreeFilter.java
+++ b/src/main/java/mesfavoris/internal/toolwindow/search/BookmarksTreeFilter.java
@@ -1,6 +1,7 @@
 package mesfavoris.internal.toolwindow.search;
 
 import mesfavoris.model.*;
+import mesfavoris.tags.Tags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -153,13 +154,24 @@ public class BookmarksTreeFilter {
     }
 
     private boolean matchesSearchText(@NotNull Bookmark bookmark) {
+        // explicit tag query (tag:xxx or #xxx) matches only against tags
+        String tagTerm = Tags.extractTagQuery(searchText);
+        if (tagTerm != null) {
+            return Tags.hasTagMatching(bookmark, tagTerm);
+        }
+
         String name = bookmark.getPropertyValue(Bookmark.PROPERTY_NAME);
         if (name != null && name.toLowerCase().contains(searchText)) {
             return true;
         }
 
         String comment = bookmark.getPropertyValue(Bookmark.PROPERTY_COMMENT);
-        return comment != null && comment.toLowerCase().contains(searchText);
+        if (comment != null && comment.toLowerCase().contains(searchText)) {
+            return true;
+        }
+
+        // free text also matches tags
+        return Tags.hasTagMatching(bookmark, searchText);
     }
 
     private void makeAncestorsVisible(@NotNull BookmarksTree bookmarksTree, @NotNull Bookmark bookmark) {

--- a/src/main/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPart.java
+++ b/src/main/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPart.java
@@ -1,0 +1,218 @@
+package mesfavoris.internal.ui.details;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.ui.CheckBoxList;
+import com.intellij.ui.CheckBoxListListener;
+import com.intellij.ui.DocumentAdapter;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.JBScrollPane;
+import com.intellij.ui.components.JBTextField;
+import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.UIUtil;
+import mesfavoris.BookmarksException;
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarkDatabase;
+import mesfavoris.model.BookmarkFolder;
+import mesfavoris.service.IBookmarksService;
+import mesfavoris.tags.Tags;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import javax.swing.event.DocumentEvent;
+import java.awt.*;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+
+/**
+ * Detail part to display and edit the tags of a bookmark. Tags are entered as a comma-separated list in a
+ * text field, and the tags already in use across all bookmarks are shown as a checklist below (checking a
+ * box adds the tag to the current bookmark, unchecking removes it). Only leaf bookmarks can be tagged.
+ */
+public class TagsBookmarkDetailPart extends AbstractBookmarkDetailPart {
+    private JPanel component;
+    private JBTextField tagsField;
+    private CheckBoxList<String> tagsList;
+    private boolean updating = false;
+
+    public TagsBookmarkDetailPart(Project project) {
+        this(project, project.getService(IBookmarksService.class).getBookmarkDatabase());
+    }
+
+    public TagsBookmarkDetailPart(Project project, BookmarkDatabase bookmarkDatabase) {
+        super(project, bookmarkDatabase);
+    }
+
+    @Override
+    public JComponent createComponent() {
+        component = new JPanel(new BorderLayout());
+        component.setBorder(JBUI.Borders.empty(5));
+
+        tagsField = new JBTextField();
+        tagsField.getEmptyText().setText("Tags separated by commas");
+        // apply tags live as the user types, without reformatting the field mid-typing
+        tagsField.getDocument().addDocumentListener(new DocumentAdapter() {
+            @Override
+            protected void textChanged(@NotNull DocumentEvent e) {
+                liveUpdateFromField();
+            }
+        });
+        // normalize the field content once editing is done
+        tagsField.addActionListener(e -> normalizeField());
+        tagsField.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusLost(FocusEvent e) {
+                normalizeField();
+            }
+        });
+
+        JBLabel hint = new JBLabel("Use tags to organize and find your bookmarks");
+        hint.setComponentStyle(UIUtil.ComponentStyle.SMALL);
+        hint.setForeground(UIUtil.getContextHelpForeground());
+        hint.setBorder(JBUI.Borders.emptyTop(3));
+
+        JPanel header = new JPanel(new BorderLayout());
+        header.add(tagsField, BorderLayout.NORTH);
+        header.add(hint, BorderLayout.CENTER);
+        header.setBorder(JBUI.Borders.emptyBottom(5));
+
+        tagsList = new CheckBoxList<>();
+        tagsList.setCheckBoxListListener(new CheckBoxListListener() {
+            @Override
+            public void checkBoxSelectionChanged(int index, boolean value) {
+                if (updating) {
+                    return;
+                }
+                setTagChecked(tagsList.getItemAt(index), value);
+            }
+        });
+
+        component.add(header, BorderLayout.NORTH);
+        component.add(new JBScrollPane(tagsList), BorderLayout.CENTER);
+        return component;
+    }
+
+    /**
+     * Called on every keystroke: persists the typed tags but leaves the field text untouched so typing (and
+     * the caret) is not disturbed. The checklist is intentionally NOT rebuilt here — it is an O(N) tree scan
+     * and the set of known tags does not meaningfully change mid-word; it is refreshed on commit
+     * ({@link #normalizeField()}) and on external changes instead.
+     */
+    private void liveUpdateFromField() {
+        if (updating || bookmark == null) {
+            return;
+        }
+        persistTags(tagsField.getText(), false);
+    }
+
+    /**
+     * Called when editing is done (Enter / focus lost): reformats the field to the canonical tags form.
+     */
+    private void normalizeField() {
+        if (updating || bookmark == null) {
+            return;
+        }
+        persistTags(tagsField.getText(), true);
+        rebuildTagsList();
+    }
+
+    /**
+     * Adds or removes the given tag on the current bookmark. Package-private so the checklist wiring can be
+     * exercised in tests (the {@link CheckBoxList} click path is not publicly triggerable).
+     */
+    void setTagChecked(String tag, boolean checked) {
+        if (bookmark == null || tag == null) {
+            return;
+        }
+        String current = bookmark.getPropertyValue(PROP_TAGS);
+        persistTags(checked ? Tags.addTag(current, tag) : Tags.removeTag(current, tag), true);
+    }
+
+    private void persistTags(String rawTags, boolean updateField) {
+        if (bookmark == null) {
+            return;
+        }
+        String normalized = Tags.format(Tags.parse(rawTags));
+        try {
+            bookmarkDatabase.modify(
+                    modifier -> modifier.setPropertyValue(bookmark.getId(), PROP_TAGS, normalized),
+                    bookmarksTree -> bookmark = bookmarksTree.getBookmark(bookmark.getId()));
+        } catch (BookmarksException e) {
+            // never happens
+        }
+        if (updateField) {
+            setFieldText(normalized);
+        }
+    }
+
+    @Override
+    public void setBookmark(Bookmark bookmark) {
+        super.setBookmark(bookmark);
+        boolean editable = this.bookmark != null && bookmarkDatabase.getBookmarksModificationValidator()
+                .validateModification(bookmarkDatabase.getBookmarksTree(), this.bookmark.getId())
+                .isOk();
+        setFieldText(this.bookmark != null ? Tags.format(Tags.getTags(this.bookmark)) : null);
+        tagsField.setEnabled(editable);
+        tagsList.setEnabled(editable);
+        rebuildTagsList();
+    }
+
+    @Override
+    public boolean canHandle(Bookmark bookmark) {
+        // tags apply to leaf bookmarks only, not folders
+        return !(bookmark instanceof BookmarkFolder);
+    }
+
+    @Override
+    public String getTitle() {
+        return "Tags";
+    }
+
+    private void setFieldText(String text) {
+        updating = true;
+        try {
+            tagsField.setText(text == null ? "" : text);
+        } finally {
+            updating = false;
+        }
+    }
+
+    /**
+     * Repopulates the checklist with every tag in use across the tree, checking those the current bookmark
+     * carries.
+     */
+    private void rebuildTagsList() {
+        updating = true;
+        try {
+            Map<String, Boolean> items = new LinkedHashMap<>();
+            if (bookmark != null) {
+                Set<String> current = new HashSet<>();
+                for (String tag : Tags.getTags(bookmark)) {
+                    current.add(tag.toLowerCase());
+                }
+                for (String tag : Tags.collectAllTags(bookmarkDatabase.getBookmarksTree())) {
+                    items.put(tag, current.contains(tag.toLowerCase()));
+                }
+            }
+            tagsList.setStringItems(items);
+        } finally {
+            updating = false;
+        }
+    }
+
+    @Override
+    protected void bookmarkModified(Bookmark oldBookmark, Bookmark newBookmark) {
+        String oldTags = oldBookmark == null ? null : oldBookmark.getPropertyValue(PROP_TAGS);
+        String newTags = newBookmark == null ? null : newBookmark.getPropertyValue(PROP_TAGS);
+        if (!Objects.equals(newTags, oldTags)) {
+            setFieldText(newTags);
+            rebuildTagsList();
+        }
+    }
+}

--- a/src/main/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPart.java
+++ b/src/main/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPart.java
@@ -10,6 +10,7 @@ import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import mesfavoris.BookmarksException;
+import mesfavoris.internal.tags.TagsIndex;
 import mesfavoris.model.Bookmark;
 import mesfavoris.model.BookmarkDatabase;
 import mesfavoris.model.BookmarkFolder;
@@ -36,17 +37,19 @@ import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
  * box adds the tag to the current bookmark, unchecking removes it). Only leaf bookmarks can be tagged.
  */
 public class TagsBookmarkDetailPart extends AbstractBookmarkDetailPart {
+    private final TagsIndex tagsIndex;
     private JPanel component;
     private JBTextField tagsField;
     private CheckBoxList<String> tagsList;
     private boolean updating = false;
 
     public TagsBookmarkDetailPart(Project project) {
-        this(project, project.getService(IBookmarksService.class).getBookmarkDatabase());
+        this(project, project.getService(IBookmarksService.class).getBookmarkDatabase(), TagsIndex.getInstance(project));
     }
 
-    public TagsBookmarkDetailPart(Project project, BookmarkDatabase bookmarkDatabase) {
+    public TagsBookmarkDetailPart(Project project, BookmarkDatabase bookmarkDatabase, TagsIndex tagsIndex) {
         super(project, bookmarkDatabase);
+        this.tagsIndex = tagsIndex;
     }
 
     @Override
@@ -196,7 +199,7 @@ public class TagsBookmarkDetailPart extends AbstractBookmarkDetailPart {
                 for (String tag : Tags.getTags(bookmark)) {
                     current.add(tag.toLowerCase());
                 }
-                for (String tag : Tags.collectAllTags(bookmarkDatabase.getBookmarksTree())) {
+                for (String tag : tagsIndex.getAllTags()) {
                     items.put(tag, current.contains(tag.toLowerCase()));
                 }
             }

--- a/src/main/java/mesfavoris/internal/ui/virtual/ExtendedBookmarksTreeModel.java
+++ b/src/main/java/mesfavoris/internal/ui/virtual/ExtendedBookmarksTreeModel.java
@@ -133,8 +133,12 @@ public class ExtendedBookmarksTreeModel extends BaseTreeModel<Object> implements
         Map<BookmarkId, BookmarkLinkNode> folderCache =
             linkNodeCache.computeIfAbsent(virtualBookmarkFolder, k -> new ConcurrentHashMap<>());
 
+        List<Object> result = new ArrayList<>();
+
+        // Nested virtual folders come first (they are non-leaf, expandable)
+        result.addAll(virtualBookmarkFolder.getChildFolders());
+
         // Convert BookmarkLink to BookmarkLinkNode using cache
-        List<Object> result = new ArrayList<>(links.size());
         for (BookmarkLink link : links) {
             BookmarkLinkNode node = folderCache.computeIfAbsent(
                 link.getBookmark().getId(),

--- a/src/main/java/mesfavoris/internal/ui/virtual/VirtualBookmarkFolder.java
+++ b/src/main/java/mesfavoris/internal/ui/virtual/VirtualBookmarkFolder.java
@@ -38,6 +38,14 @@ public abstract class VirtualBookmarkFolder implements IAdaptable {
 
 	public abstract List<BookmarkLink> getChildren();
 
+	/**
+	 * Returns the virtual sub-folders of this folder. Default is none; override to expose nested virtual
+	 * folders (e.g. one folder per tag). Nested folders are shown before the {@link BookmarkLink} children.
+	 */
+	public List<VirtualBookmarkFolder> getChildFolders() {
+		return List.of();
+	}
+
 	public synchronized void addListener(IVirtualBookmarkFolderListener listener) {
 		if (listenerList.isEmpty()) {
 			initListening();

--- a/src/main/java/mesfavoris/tags/Tags.java
+++ b/src/main/java/mesfavoris/tags/Tags.java
@@ -1,0 +1,137 @@
+package mesfavoris.tags;
+
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarksTree;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+
+/**
+ * Pure helpers to read, write and query bookmark tags. Tags are stored in the {@code tags} property as a
+ * comma-separated string. Tag names cannot contain commas and are compared case-insensitively (their
+ * display casing is preserved).
+ */
+public class Tags {
+	private static final String SEPARATOR = ",";
+
+	private Tags() {
+	}
+
+	/**
+	 * Parses a raw tags string into an ordered, de-duplicated (case-insensitive) list of tag names.
+	 * Blank entries are dropped and each name is trimmed.
+	 */
+	public static List<String> parse(String raw) {
+		if (raw == null || raw.isBlank()) {
+			return List.of();
+		}
+		Set<String> lowerSeen = new LinkedHashSet<>();
+		List<String> result = new ArrayList<>();
+		for (String part : raw.split(SEPARATOR)) {
+			String tag = part.trim();
+			if (tag.isEmpty()) {
+				continue;
+			}
+			if (lowerSeen.add(tag.toLowerCase())) {
+				result.add(tag);
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Formats a collection of tags into a canonical, case-insensitively sorted, comma-separated string.
+	 * Returns {@code null} when the result would be empty (so the property gets removed).
+	 */
+	public static String format(Collection<String> tags) {
+		SortedSet<String> sorted = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+		for (String tag : tags) {
+			if (tag != null && !tag.trim().isEmpty()) {
+				sorted.add(tag.trim());
+			}
+		}
+		if (sorted.isEmpty()) {
+			return null;
+		}
+		return String.join(SEPARATOR, sorted);
+	}
+
+	/**
+	 * Returns the raw string with {@code tag} added (no-op if already present, case-insensitively).
+	 */
+	public static String addTag(String raw, String tag) {
+		List<String> tags = new ArrayList<>(parse(raw));
+		String trimmed = tag == null ? "" : tag.trim();
+		if (!trimmed.isEmpty() && tags.stream().noneMatch(t -> t.equalsIgnoreCase(trimmed))) {
+			tags.add(trimmed);
+		}
+		return format(tags);
+	}
+
+	/**
+	 * Returns the raw string with {@code tag} removed (case-insensitively).
+	 */
+	public static String removeTag(String raw, String tag) {
+		List<String> tags = new ArrayList<>(parse(raw));
+		String trimmed = tag == null ? "" : tag.trim();
+		tags.removeIf(t -> t.equalsIgnoreCase(trimmed));
+		return format(tags);
+	}
+
+	/**
+	 * Returns the tags of the given bookmark.
+	 */
+	public static List<String> getTags(Bookmark bookmark) {
+		return parse(bookmark.getPropertyValue(PROP_TAGS));
+	}
+
+	/**
+	 * Collects every distinct tag used across the whole tree, ordered case-insensitively.
+	 */
+	public static SortedSet<String> collectAllTags(BookmarksTree tree) {
+		SortedSet<String> all = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+		for (Bookmark bookmark : tree) {
+			all.addAll(getTags(bookmark));
+		}
+		return all;
+	}
+
+	/**
+	 * Returns true if the bookmark has any tag that contains {@code term} (case-insensitive substring).
+	 * A blank term matches any bookmark that has at least one tag.
+	 */
+	public static boolean hasTagMatching(Bookmark bookmark, String term) {
+		String lower = term == null ? "" : term.toLowerCase().trim();
+		List<String> tags = getTags(bookmark);
+		if (lower.isEmpty()) {
+			return !tags.isEmpty();
+		}
+		return tags.stream().anyMatch(t -> t.toLowerCase().contains(lower));
+	}
+
+	/**
+	 * Extracts the tag search term from a search query if it is a tag query ({@code tag:xxx} or
+	 * {@code #xxx}); returns {@code null} otherwise. The returned term is trimmed and lower-cased.
+	 */
+	public static String extractTagQuery(String searchText) {
+		if (searchText == null) {
+			return null;
+		}
+		String trimmed = searchText.trim();
+		String lower = trimmed.toLowerCase();
+		if (lower.startsWith("tag:")) {
+			return trimmed.substring("tag:".length()).trim().toLowerCase();
+		}
+		if (trimmed.startsWith("#")) {
+			return trimmed.substring(1).trim().toLowerCase();
+		}
+		return null;
+	}
+}

--- a/src/main/java/mesfavoris/tags/Tags.java
+++ b/src/main/java/mesfavoris/tags/Tags.java
@@ -15,8 +15,8 @@ import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
 
 /**
  * Pure helpers to read, write and query bookmark tags. Tags are stored in the {@code tags} property as a
- * comma-separated string. Tag names cannot contain commas and are compared case-insensitively (their
- * display casing is preserved).
+ * comma-separated string. Tag names cannot contain commas and are normalized to lower case (tags are
+ * case-insensitive and always displayed in lower case).
  */
 public class Tags {
 	private static final String SEPARATOR = ",";
@@ -25,36 +25,35 @@ public class Tags {
 	}
 
 	/**
-	 * Parses a raw tags string into an ordered, de-duplicated (case-insensitive) list of tag names.
-	 * Blank entries are dropped and each name is trimmed.
+	 * Parses a raw tags string into an ordered, de-duplicated list of lower-case tag names. Blank entries
+	 * are dropped and each name is trimmed.
 	 */
 	public static List<String> parse(String raw) {
 		if (raw == null || raw.isBlank()) {
 			return List.of();
 		}
-		Set<String> lowerSeen = new LinkedHashSet<>();
-		List<String> result = new ArrayList<>();
+		Set<String> tags = new LinkedHashSet<>();
 		for (String part : raw.split(SEPARATOR)) {
-			String tag = part.trim();
-			if (tag.isEmpty()) {
-				continue;
-			}
-			if (lowerSeen.add(tag.toLowerCase())) {
-				result.add(tag);
+			String tag = part.trim().toLowerCase();
+			if (!tag.isEmpty()) {
+				tags.add(tag);
 			}
 		}
-		return result;
+		return new ArrayList<>(tags);
 	}
 
 	/**
-	 * Formats a collection of tags into a canonical, case-insensitively sorted, comma-separated string.
-	 * Returns {@code null} when the result would be empty (so the property gets removed).
+	 * Formats a collection of tags into a canonical, sorted, lower-case comma-separated string. Returns
+	 * {@code null} when the result would be empty (so the property gets removed).
 	 */
 	public static String format(Collection<String> tags) {
-		SortedSet<String> sorted = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+		SortedSet<String> sorted = new TreeSet<>();
 		for (String tag : tags) {
-			if (tag != null && !tag.trim().isEmpty()) {
-				sorted.add(tag.trim());
+			if (tag != null) {
+				String normalized = tag.trim().toLowerCase();
+				if (!normalized.isEmpty()) {
+					sorted.add(normalized);
+				}
 			}
 		}
 		if (sorted.isEmpty()) {
@@ -64,24 +63,23 @@ public class Tags {
 	}
 
 	/**
-	 * Returns the raw string with {@code tag} added (no-op if already present, case-insensitively).
+	 * Returns the raw string with {@code tag} added (no-op if already present).
 	 */
 	public static String addTag(String raw, String tag) {
 		List<String> tags = new ArrayList<>(parse(raw));
-		String trimmed = tag == null ? "" : tag.trim();
-		if (!trimmed.isEmpty() && tags.stream().noneMatch(t -> t.equalsIgnoreCase(trimmed))) {
-			tags.add(trimmed);
+		String normalized = tag == null ? "" : tag.trim().toLowerCase();
+		if (!normalized.isEmpty() && !tags.contains(normalized)) {
+			tags.add(normalized);
 		}
 		return format(tags);
 	}
 
 	/**
-	 * Returns the raw string with {@code tag} removed (case-insensitively).
+	 * Returns the raw string with {@code tag} removed.
 	 */
 	public static String removeTag(String raw, String tag) {
 		List<String> tags = new ArrayList<>(parse(raw));
-		String trimmed = tag == null ? "" : tag.trim();
-		tags.removeIf(t -> t.equalsIgnoreCase(trimmed));
+		tags.remove(tag == null ? "" : tag.trim().toLowerCase());
 		return format(tags);
 	}
 
@@ -93,10 +91,10 @@ public class Tags {
 	}
 
 	/**
-	 * Collects every distinct tag used across the whole tree, ordered case-insensitively.
+	 * Collects every distinct tag used across the whole tree, sorted.
 	 */
 	public static SortedSet<String> collectAllTags(BookmarksTree tree) {
-		SortedSet<String> all = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+		SortedSet<String> all = new TreeSet<>();
 		for (Bookmark bookmark : tree) {
 			all.addAll(getTags(bookmark));
 		}
@@ -113,7 +111,7 @@ public class Tags {
 		if (lower.isEmpty()) {
 			return !tags.isEmpty();
 		}
-		return tags.stream().anyMatch(t -> t.toLowerCase().contains(lower));
+		return tags.stream().anyMatch(t -> t.contains(lower));
 	}
 
 	/**

--- a/src/main/java/mesfavoris/tags/TagsBookmarkProperties.java
+++ b/src/main/java/mesfavoris/tags/TagsBookmarkProperties.java
@@ -1,0 +1,14 @@
+package mesfavoris.tags;
+
+/**
+ * Property names for bookmark tags.
+ */
+public class TagsBookmarkProperties {
+	/**
+	 * Comma-separated list of tags, e.g. "bug,perf". Stored on leaf bookmarks only.
+	 */
+	public static final String PROP_TAGS = "tags";
+
+	private TagsBookmarkProperties() {
+	}
+}

--- a/src/main/java/mesfavoris/ui/renderers/BookmarksTreeCellRenderer.java
+++ b/src/main/java/mesfavoris/ui/renderers/BookmarksTreeCellRenderer.java
@@ -8,6 +8,7 @@ import com.intellij.ui.ColoredTreeCellRenderer;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.LayeredIcon;
 import com.intellij.ui.SimpleTextAttributes;
+import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
 import mesfavoris.bookmarktype.IBookmarkLabelProvider;
 import mesfavoris.commons.Adapters;
@@ -22,6 +23,7 @@ import mesfavoris.persistence.IBookmarksDirtyStateListener;
 import mesfavoris.persistence.IBookmarksDirtyStateTracker;
 import mesfavoris.remote.IRemoteBookmarksStore;
 import mesfavoris.remote.RemoteBookmarksStoreManager;
+import mesfavoris.tags.Tags;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -39,6 +41,9 @@ public class BookmarksTreeCellRenderer extends ColoredTreeCellRenderer implement
     private final IBookmarksDirtyStateTracker bookmarksDirtyStateTracker;
     private final Color commentColor = new JBColor(new Color(63, 127, 95), new Color(63, 127, 95));
     private static final Color AI_BADGE_COLOR = new JBColor(new Color(155, 89, 214), new Color(176, 127, 232));
+    // discreet grey tags: grey text with a thin grey outline, no fill
+    private static final Color TAG_FG_COLOR = new JBColor(new Color(120, 120, 120), new Color(140, 140, 140));
+    private static final Color TAG_BORDER_COLOR = new JBColor(new Color(180, 180, 180), new Color(90, 90, 90));
     private final IBookmarksDirtyStateListener dirtyStateListener = dirtyBookmarks -> ApplicationManager.getApplication().invokeLater(() -> {
         JTree tree = getTree();
         if (tree == null || !tree.isShowing()) {
@@ -70,6 +75,25 @@ public class BookmarksTreeCellRenderer extends ColoredTreeCellRenderer implement
         styledText.appendTo(this);
         Icon icon = getIcon(value);
         setIcon(icon);
+    }
+
+    @Override
+    protected void doPaintFragmentBackground(@NotNull Graphics2D g, int index, @NotNull Color bgColor, int x, int y, int width, int height) {
+        // draw tag fragments as rounded "pills" instead of the default rectangle
+        Object oldAntialiasing = g.getRenderingHint(RenderingHints.KEY_ANTIALIASING);
+        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        try {
+            int verticalInset = JBUI.scale(3);
+            int pillHeight = height - 2 * verticalInset;
+            int top = y + verticalInset;
+            int arc = JBUI.scale(9);
+            // outline only (no fill) for a discreet look
+            g.setColor(TAG_BORDER_COLOR);
+            g.drawRoundRect(x, top, width - 1, pillHeight - 1, arc, arc);
+        } finally {
+            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING,
+                    oldAntialiasing != null ? oldAntialiasing : RenderingHints.VALUE_ANTIALIAS_DEFAULT);
+        }
     }
 
     private Icon getIcon(final Object element) {
@@ -107,6 +131,18 @@ public class BookmarksTreeCellRenderer extends ColoredTreeCellRenderer implement
                 && McpBookmarkProperties.ORIGIN_MCP.equals(bookmark.getPropertyValue(McpBookmarkProperties.PROPERTY_ORIGIN))) {
             Color badgeColor = isDisabled ? UIUtil.getInactiveTextColor() : AI_BADGE_COLOR;
             styledString = styledString.append(" [AI]", new SimpleTextAttributes(SimpleTextAttributes.STYLE_PLAIN, badgeColor));
+        }
+
+        if (!(bookmark instanceof BookmarkFolder)) {
+            Color tagFg = isDisabled ? UIUtil.getInactiveTextColor() : TAG_FG_COLOR;
+            // STYLE_OPAQUE (with a non-null bg) is required so SimpleColoredComponent invokes
+            // doPaintFragmentBackground, where we draw the outline; the bg itself is not filled.
+            SimpleTextAttributes tagAttributes = new SimpleTextAttributes(TAG_BORDER_COLOR, tagFg, null,
+                    SimpleTextAttributes.STYLE_SMALLER | SimpleTextAttributes.STYLE_OPAQUE);
+            for (String tag : Tags.getTags(bookmark)) {
+                styledString = styledString.append(" ");
+                styledString = styledString.append(" " + tag + " ", tagAttributes);
+            }
         }
 
         if (hasComment) {

--- a/src/test/java/mesfavoris/internal/mcp/BookmarksMcpToolsetTest.kt
+++ b/src/test/java/mesfavoris/internal/mcp/BookmarksMcpToolsetTest.kt
@@ -727,6 +727,27 @@ class MesFavorisBookmarksMcpToolsetTest : BasePlatformTestCase() {
         }
     }
 
+    @Test
+    fun testModifyBookmarkSetsTags() {
+        runBlocking {
+            toolset.modify_bookmark(id = taskBookmarkId.toString(), properties = mapOf("tags" to "bug,perf"))
+
+            val bookmark = bookmarkDatabase.getBookmarksTree().getBookmark(taskBookmarkId)
+            assertThat(bookmark?.getPropertyValue("tags")).isEqualTo("bug,perf")
+        }
+    }
+
+    @Test
+    fun testTagsAreReturnedWhenRequested() {
+        runBlocking {
+            toolset.modify_bookmark(id = taskBookmarkId.toString(), properties = mapOf("tags" to "bug,perf"))
+
+            val results = toolset.search_bookmarks(query = "Daily Task", returnProperties = "name,tags").bookmarks
+            assertThat(results).isNotEmpty
+            assertThat(results[0].properties["tags"]).isEqualTo("bug,perf")
+        }
+    }
+
     // --- update_bookmark ---
 
     @Test

--- a/src/test/java/mesfavoris/internal/tags/TagsIndexTest.java
+++ b/src/test/java/mesfavoris/internal/tags/TagsIndexTest.java
@@ -1,0 +1,109 @@
+package mesfavoris.internal.tags;
+
+import mesfavoris.BookmarksException;
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.BookmarksTree;
+import mesfavoris.model.modification.IBookmarksTreeModifier;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+import static mesfavoris.tests.commons.bookmarks.BookmarkBuilder.bookmark;
+import static mesfavoris.tests.commons.bookmarks.BookmarkBuilder.bookmarkFolder;
+import static mesfavoris.tests.commons.bookmarks.BookmarksTreeBuilder.bookmarksTree;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TagsIndexTest {
+	private final BookmarkId rootId = new BookmarkId("root");
+	private final BookmarkId folderId = new BookmarkId("folder");
+	private final BookmarkId b1 = new BookmarkId("b1");
+	private final BookmarkId b2 = new BookmarkId("b2");
+	private mesfavoris.model.BookmarkDatabase bookmarkDatabase;
+	private TagsIndex tagsIndex;
+
+	@Before
+	public void setUp() {
+		BookmarksTree tree = bookmarksTree("root")
+				.addBookmarks("root",
+						bookmark(b1, "B1").withProperty(PROP_TAGS, "bug,perf"),
+						bookmark(b2, "B2").withProperty(PROP_TAGS, "Perf"))
+				.build();
+		bookmarkDatabase = new mesfavoris.model.BookmarkDatabase("test", tree);
+		tagsIndex = new TagsIndex(bookmarkDatabase);
+	}
+
+	@Test
+	public void testInitialBuild() {
+		assertThat(tagsIndex.getAllTags()).containsExactly("bug", "perf");
+		assertThat(tagsIndex.getBookmarkIds("perf")).containsExactlyInAnyOrder(b1, b2);
+		assertThat(tagsIndex.getBookmarkIds("bug")).containsExactly(b1);
+	}
+
+	@Test
+	public void testGetBookmarkIdsIsCaseInsensitive() {
+		assertThat(tagsIndex.getBookmarkIds("PERF")).containsExactlyInAnyOrder(b1, b2);
+	}
+
+	@Test
+	public void testAddingBookmarkIndexesItsTags() throws BookmarksException {
+		tagsIndex.getAllTags(); // force initial build so the add goes through the event path
+		modify(m -> m.addBookmarks(rootId, List.of(
+				bookmark(new BookmarkId("b3"), "B3").withProperty(PROP_TAGS, "ui").build())));
+
+		assertThat(tagsIndex.getAllTags()).contains("ui");
+		assertThat(tagsIndex.getBookmarkIds("ui")).containsExactly(new BookmarkId("b3"));
+	}
+
+	@Test
+	public void testChangingTagsPropertyUpdatesIndex() throws BookmarksException {
+		tagsIndex.getAllTags();
+		modify(m -> m.setPropertyValue(b1, PROP_TAGS, "perf,ui"));
+
+		// "bug" was only on b1 -> gone; "ui" added; b1 still under "perf"
+		assertThat(tagsIndex.getBookmarkIds("bug")).isEmpty();
+		assertThat(tagsIndex.getBookmarkIds("ui")).containsExactly(b1);
+		assertThat(tagsIndex.getBookmarkIds("perf")).containsExactlyInAnyOrder(b1, b2);
+	}
+
+	@Test
+	public void testRemovingLastBookmarkForTagRemovesTag() throws BookmarksException {
+		tagsIndex.getAllTags();
+		modify(m -> m.setPropertyValue(b1, PROP_TAGS, "perf"));
+
+		assertThat(tagsIndex.getAllTags()).doesNotContain("bug");
+	}
+
+	@Test
+	public void testDeletingBookmarkRemovesItsTags() throws BookmarksException {
+		tagsIndex.getAllTags();
+		modify(m -> m.deleteBookmark(b1, false));
+
+		assertThat(tagsIndex.getBookmarkIds("bug")).isEmpty();
+		assertThat(tagsIndex.getBookmarkIds("perf")).containsExactly(b2);
+	}
+
+	@Test
+	public void testDeletingFolderRecursivelyRemovesDescendantTags() throws BookmarksException {
+		// move b1,b2 under a folder, then delete the folder recursively
+		BookmarksTree tree = bookmarksTree("root")
+				.addBookmarks("root", bookmarkFolder(folderId, "folder"))
+				.addBookmarks(folderId,
+						bookmark(b1, "B1").withProperty(PROP_TAGS, "bug"),
+						bookmark(b2, "B2").withProperty(PROP_TAGS, "perf"))
+				.build();
+		bookmarkDatabase = new mesfavoris.model.BookmarkDatabase("test", tree);
+		tagsIndex = new TagsIndex(bookmarkDatabase);
+		assertThat(tagsIndex.getAllTags()).containsExactly("bug", "perf");
+
+		modify(m -> m.deleteBookmark(folderId, true));
+
+		assertThat(tagsIndex.getAllTags()).isEmpty();
+	}
+
+	private void modify(java.util.function.Consumer<IBookmarksTreeModifier> operation) throws BookmarksException {
+		bookmarkDatabase.modify(operation::accept);
+	}
+}

--- a/src/test/java/mesfavoris/internal/tags/TagsVirtualFolderTest.java
+++ b/src/test/java/mesfavoris/internal/tags/TagsVirtualFolderTest.java
@@ -1,0 +1,92 @@
+package mesfavoris.internal.tags;
+
+import mesfavoris.internal.ui.virtual.BookmarkLink;
+import mesfavoris.internal.ui.virtual.IVirtualBookmarkFolderListener;
+import mesfavoris.internal.ui.virtual.VirtualBookmarkFolder;
+import mesfavoris.model.BookmarkDatabase;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.BookmarksTree;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+import static mesfavoris.tests.commons.bookmarks.BookmarkBuilder.bookmark;
+import static mesfavoris.tests.commons.bookmarks.BookmarksTreeBuilder.bookmarksTree;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TagsVirtualFolderTest {
+	private final BookmarkId rootId = new BookmarkId("root");
+	private final BookmarkId b1 = new BookmarkId("b1");
+	private final BookmarkId b2 = new BookmarkId("b2");
+	private final BookmarkId b3 = new BookmarkId("b3");
+	private BookmarkDatabase bookmarkDatabase;
+	private TagsRootVirtualFolder tagsRoot;
+
+	@Before
+	public void setUp() {
+		BookmarksTree tree = bookmarksTree("root")
+				.addBookmarks("root",
+						bookmark(b1, "B1").withProperty(PROP_TAGS, "bug,perf"),
+						bookmark(b2, "B2").withProperty(PROP_TAGS, "Perf"),
+						bookmark(b3, "B3"))
+				.build();
+		bookmarkDatabase = new BookmarkDatabase("test", tree);
+		tagsRoot = new TagsRootVirtualFolder(bookmarkDatabase, rootId);
+	}
+
+	@Test
+	public void testRootExposesOneFolderPerTag() {
+		List<VirtualBookmarkFolder> folders = tagsRoot.getChildFolders();
+		assertThat(folders).extracting(f -> ((TagVirtualFolder) f).getTag())
+				.containsExactly("bug", "perf");
+		assertThat(tagsRoot.getChildren()).isEmpty();
+	}
+
+	@Test
+	public void testTagFolderListsMatchingBookmarksCaseInsensitively() {
+		TagVirtualFolder perf = folderForTag("perf");
+		assertThat(perf.getChildren()).extracting(link -> link.getBookmark().getId())
+				.containsExactlyInAnyOrder(b1, b2);
+
+		TagVirtualFolder bug = folderForTag("bug");
+		assertThat(bug.getChildren()).extracting(link -> link.getBookmark().getId())
+				.containsExactly(b1);
+	}
+
+	@Test
+	public void testChildFoldersReuseInstancesAcrossCalls() {
+		VirtualBookmarkFolder before = tagsRoot.getChildFolders().get(0);
+		VirtualBookmarkFolder after = tagsRoot.getChildFolders().get(0);
+		assertThat(after).isSameAs(before);
+	}
+
+	@Test
+	public void testFoldersAreRemovedWhenTagDisappears() throws Exception {
+		bookmarkDatabase.modify(modifier -> modifier.setPropertyValue(b1, PROP_TAGS, "perf"));
+		// "bug" was only on b1; it should be gone now
+		assertThat(tagsRoot.getChildFolders()).extracting(f -> ((TagVirtualFolder) f).getTag())
+				.containsExactly("perf");
+	}
+
+	@Test
+	public void testListenerFiresWhenBookmarksChange() throws Exception {
+		AtomicInteger count = new AtomicInteger();
+		IVirtualBookmarkFolderListener listener = folder -> count.incrementAndGet();
+		tagsRoot.addListener(listener);
+
+		bookmarkDatabase.modify(modifier -> modifier.setPropertyValue(b3, PROP_TAGS, "ui"));
+
+		assertThat(count.get()).isGreaterThanOrEqualTo(1);
+		assertThat(tagsRoot.getChildFolders()).extracting(f -> ((TagVirtualFolder) f).getTag())
+				.contains("ui");
+	}
+
+	private TagVirtualFolder folderForTag(String tag) {
+		return (TagVirtualFolder) tagsRoot.getChildFolders().stream()
+				.filter(f -> ((TagVirtualFolder) f).getTag().equalsIgnoreCase(tag))
+				.findFirst().orElseThrow();
+	}
+}

--- a/src/test/java/mesfavoris/internal/tags/TagsVirtualFolderTest.java
+++ b/src/test/java/mesfavoris/internal/tags/TagsVirtualFolderTest.java
@@ -34,7 +34,7 @@ public class TagsVirtualFolderTest {
 						bookmark(b3, "B3"))
 				.build();
 		bookmarkDatabase = new BookmarkDatabase("test", tree);
-		tagsRoot = new TagsRootVirtualFolder(bookmarkDatabase, rootId);
+		tagsRoot = new TagsRootVirtualFolder(bookmarkDatabase, new TagsIndex(bookmarkDatabase), rootId);
 	}
 
 	@Test

--- a/src/test/java/mesfavoris/internal/toolwindow/BookmarksTreeFilterTest.java
+++ b/src/test/java/mesfavoris/internal/toolwindow/BookmarksTreeFilterTest.java
@@ -12,6 +12,7 @@ import java.util.Set;
 
 import static mesfavoris.tests.commons.bookmarks.BookmarkBuilder.bookmark;
 import static mesfavoris.tests.commons.bookmarks.BookmarkBuilder.bookmarkFolder;
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
 import static mesfavoris.tests.commons.bookmarks.BookmarksTreeBuilder.bookmarksTree;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,9 +38,11 @@ public class BookmarksTreeFilterTest {
         BookmarksTree bookmarksTree = bookmarksTree("root")
                 .addBookmarks("root",
                         bookmark(bookmark1Id, "Java Tutorial")
-                                .withProperty(Bookmark.PROPERTY_COMMENT, "Learn Java basics"),
+                                .withProperty(Bookmark.PROPERTY_COMMENT, "Learn Java basics")
+                                .withProperty(PROP_TAGS, "favorite,beginner"),
                         bookmark(bookmark2Id, "Python Guide")
-                                .withProperty(Bookmark.PROPERTY_COMMENT, "Advanced Python"),
+                                .withProperty(Bookmark.PROPERTY_COMMENT, "Advanced Python")
+                                .withProperty(PROP_TAGS, "reference"),
                         bookmarkFolder(folder1Id, "Development"))
                 .addBookmarks(folder1Id,
                         bookmark(bookmark3Id, "IntelliJ IDEA")
@@ -142,6 +145,39 @@ public class BookmarksTreeFilterTest {
         assertThat(filter.matches(getBookmark(folder1Id))).isTrue();
         assertThat(filter.isVisible(getBookmark(bookmark3Id))).isTrue();
         assertThat(filter.matches(getBookmark(bookmark3Id))).isTrue();
+    }
+
+    @Test
+    public void testFilterByTagQuery() {
+        // When
+        filter.setSearchText("tag:favorite");
+
+        // Then - only the bookmark tagged "favorite" matches (not by name/comment)
+        assertThat(filter.isVisible(getBookmark(bookmark1Id))).isTrue();
+        assertThat(filter.matches(getBookmark(bookmark1Id))).isTrue();
+        assertThat(filter.isVisible(getBookmark(bookmark2Id))).isFalse();
+    }
+
+    @Test
+    public void testFilterByHashTagQuery() {
+        // When
+        filter.setSearchText("#reference");
+
+        // Then
+        assertThat(filter.isVisible(getBookmark(bookmark2Id))).isTrue();
+        assertThat(filter.matches(getBookmark(bookmark2Id))).isTrue();
+        assertThat(filter.isVisible(getBookmark(bookmark1Id))).isFalse();
+    }
+
+    @Test
+    public void testFreeTextAlsoMatchesTags() {
+        // When - free text (no tag: prefix) still matches a tag
+        filter.setSearchText("beginner");
+
+        // Then
+        assertThat(filter.isVisible(getBookmark(bookmark1Id))).isTrue();
+        assertThat(filter.matches(getBookmark(bookmark1Id))).isTrue();
+        assertThat(filter.isVisible(getBookmark(bookmark2Id))).isFalse();
     }
 
     @Test

--- a/src/test/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPartTest.java
+++ b/src/test/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPartTest.java
@@ -6,6 +6,7 @@ import com.intellij.testFramework.fixtures.BasePlatformTestCase;
 import com.intellij.ui.CheckBoxList;
 import com.intellij.ui.components.JBTextField;
 import mesfavoris.BookmarksException;
+import mesfavoris.internal.tags.TagsIndex;
 import mesfavoris.model.Bookmark;
 import mesfavoris.model.BookmarkDatabase;
 import mesfavoris.model.BookmarkFolder;
@@ -45,7 +46,7 @@ public class TagsBookmarkDetailPartTest extends BasePlatformTestCase {
         addBookmark(new Bookmark(b1, ImmutableMap.of(PROPERTY_NAME, "B1", PROP_TAGS, "bug,perf")));
         addBookmark(new Bookmark(b2, ImmutableMap.of(PROPERTY_NAME, "B2", PROP_TAGS, "ui")));
 
-        detailPart = new TagsBookmarkDetailPart(getProject(), bookmarkDatabase);
+        detailPart = new TagsBookmarkDetailPart(getProject(), bookmarkDatabase, new TagsIndex(bookmarkDatabase));
         detailPart.init();
         component = (JComponent) detailPart.createComponent();
     }

--- a/src/test/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPartTest.java
+++ b/src/test/java/mesfavoris/internal/ui/details/TagsBookmarkDetailPartTest.java
@@ -1,0 +1,176 @@
+package mesfavoris.internal.ui.details;
+
+import com.google.common.collect.ImmutableMap;
+import com.intellij.testFramework.PlatformTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.intellij.ui.CheckBoxList;
+import com.intellij.ui.components.JBTextField;
+import mesfavoris.BookmarksException;
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarkDatabase;
+import mesfavoris.model.BookmarkFolder;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.BookmarksTree;
+import mesfavoris.tests.commons.ui.ComponentFinder;
+import mesfavoris.tests.commons.waits.Waiter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static mesfavoris.model.Bookmark.PROPERTY_NAME;
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+import static mesfavoris.tests.commons.bookmarks.BookmarksTreeBuilder.bookmarksTree;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TagsBookmarkDetailPartTest extends BasePlatformTestCase {
+    private BookmarkDatabase bookmarkDatabase;
+    private TagsBookmarkDetailPart detailPart;
+    private JComponent component;
+
+    private final BookmarkId b1 = new BookmarkId("b1");
+    private final BookmarkId b2 = new BookmarkId("b2");
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        BookmarksTree tree = bookmarksTree("root").build();
+        bookmarkDatabase = new BookmarkDatabase("test", tree);
+        // b1 tagged bug,perf ; b2 tagged ui
+        addBookmark(new Bookmark(b1, ImmutableMap.of(PROPERTY_NAME, "B1", PROP_TAGS, "bug,perf")));
+        addBookmark(new Bookmark(b2, ImmutableMap.of(PROPERTY_NAME, "B2", PROP_TAGS, "ui")));
+
+        detailPart = new TagsBookmarkDetailPart(getProject(), bookmarkDatabase);
+        detailPart.init();
+        component = (JComponent) detailPart.createComponent();
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        try {
+            detailPart.dispose();
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    @Test
+    public void testTitleAndCanHandle() {
+        assertThat(detailPart.getTitle()).isEqualTo("Tags");
+        assertThat(detailPart.canHandle(getBookmark(b1))).isTrue();
+        assertThat(detailPart.canHandle(new BookmarkFolder(new BookmarkId("f"), "folder"))).isFalse();
+    }
+
+    @Test
+    public void testFieldShowsNormalizedTags() {
+        // stored unsorted -> field shows canonical (sorted) form
+        modifyTags(b1, "perf, bug");
+        detailPart.setBookmark(getBookmark(b1));
+        assertThat(field().getText()).isEqualTo("bug,perf");
+    }
+
+    @Test
+    public void testChecklistReflectsAllTreeTagsWithCurrentChecked() {
+        detailPart.setBookmark(getBookmark(b1));
+
+        assertThat(checklistTags()).containsExactly("bug", "perf", "ui");
+        assertThat(checkedTags()).containsExactlyInAnyOrder("bug", "perf");
+    }
+
+    @Test
+    public void testTypingInFieldPersistsTagsLive() throws TimeoutException, BookmarksException {
+        Bookmark untagged = new Bookmark(new BookmarkId("b3"), ImmutableMap.of(PROPERTY_NAME, "B3"));
+        addBookmark(untagged);
+        detailPart.setBookmark(getBookmark(untagged.getId()));
+
+        field().setText("zeta, alpha");
+
+        Waiter.waitUntil("tags should be persisted while typing", () -> {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue();
+            return "alpha,zeta".equals(getBookmark(untagged.getId()).getPropertyValue(PROP_TAGS));
+        });
+    }
+
+    @Test
+    public void testCheckingBoxAddsTagUncheckingRemovesIt() {
+        detailPart.setBookmark(getBookmark(b1));
+
+        // b1 does not have "ui" yet -> checking it adds it
+        detailPart.setTagChecked("ui", true);
+        assertThat(tagsOf(b1)).contains("ui");
+
+        // unchecking "bug" removes it
+        detailPart.setTagChecked("bug", false);
+        assertThat(tagsOf(b1)).doesNotContain("bug");
+    }
+
+    @Test
+    public void testExternalModificationUpdatesFieldAndChecklist() throws TimeoutException {
+        detailPart.setBookmark(getBookmark(b1));
+
+        modifyTags(b1, "zzz");
+
+        Waiter.waitUntil("field and checklist reflect external change", () -> {
+            PlatformTestUtil.dispatchAllEventsInIdeEventQueue();
+            return "zzz".equals(field().getText()) && checkedTags().contains("zzz");
+        });
+    }
+
+    // --- helpers ---
+
+    private JBTextField field() {
+        return ComponentFinder.findChildComponent(component, JBTextField.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private CheckBoxList<String> checklist() {
+        return ComponentFinder.findChildComponent(component, CheckBoxList.class);
+    }
+
+    private List<String> checklistTags() {
+        CheckBoxList<String> list = checklist();
+        List<String> tags = new ArrayList<>();
+        for (int i = 0; i < list.getModel().getSize(); i++) {
+            tags.add(list.getItemAt(i));
+        }
+        return tags;
+    }
+
+    private List<String> checkedTags() {
+        CheckBoxList<String> list = checklist();
+        List<String> tags = new ArrayList<>();
+        for (int i = 0; i < list.getModel().getSize(); i++) {
+            if (list.isItemSelected(i)) {
+                tags.add(list.getItemAt(i));
+            }
+        }
+        return tags;
+    }
+
+    private List<String> tagsOf(BookmarkId id) {
+        return mesfavoris.tags.Tags.getTags(getBookmark(id));
+    }
+
+    private Bookmark getBookmark(BookmarkId id) {
+        return bookmarkDatabase.getBookmarksTree().getBookmark(id);
+    }
+
+    private void addBookmark(Bookmark bookmark) throws BookmarksException {
+        bookmarkDatabase.modify(modifier ->
+                modifier.addBookmarks(bookmarkDatabase.getBookmarksTree().getRootFolder().getId(), List.of(bookmark)));
+    }
+
+    private void modifyTags(BookmarkId id, String tags) {
+        try {
+            bookmarkDatabase.modify(modifier -> modifier.setPropertyValue(id, PROP_TAGS, tags));
+        } catch (BookmarksException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/mesfavoris/tags/TagsTest.java
+++ b/src/test/java/mesfavoris/tags/TagsTest.java
@@ -22,8 +22,8 @@ public class TagsTest {
 	}
 
 	@Test
-	public void testParseDeduplicatesCaseInsensitivelyKeepingFirst() {
-		assertEquals(List.of("Bug", "perf"), Tags.parse("Bug, bug, perf, PERF"));
+	public void testParseLowercasesAndDeduplicates() {
+		assertEquals(List.of("bug", "perf"), Tags.parse("Bug, bug, perf, PERF"));
 	}
 
 	@Test
@@ -33,9 +33,8 @@ public class TagsTest {
 	}
 
 	@Test
-	public void testFormatSortsCaseInsensitivelyAndDeduplicates() {
-		// case-insensitive sort + dedup; first-seen casing wins ("PERF" before "perf")
-		assertEquals("bug,PERF,zebra", Tags.format(List.of("zebra", "bug", "PERF", "perf")));
+	public void testFormatLowercasesSortsAndDeduplicates() {
+		assertEquals("bug,perf,zebra", Tags.format(List.of("zebra", "bug", "PERF", "perf")));
 	}
 
 	@Test

--- a/src/test/java/mesfavoris/tags/TagsTest.java
+++ b/src/test/java/mesfavoris/tags/TagsTest.java
@@ -1,0 +1,100 @@
+package mesfavoris.tags;
+
+import mesfavoris.model.Bookmark;
+import mesfavoris.model.BookmarkId;
+import mesfavoris.model.BookmarksTree;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+
+import static mesfavoris.tags.TagsBookmarkProperties.PROP_TAGS;
+import static mesfavoris.tests.commons.bookmarks.BookmarkBuilder.bookmark;
+import static mesfavoris.tests.commons.bookmarks.BookmarksTreeBuilder.bookmarksTree;
+import static org.junit.Assert.*;
+
+public class TagsTest {
+
+	@Test
+	public void testParseSplitsTrimsAndDropsEmpty() {
+		assertEquals(List.of("bug", "perf"), Tags.parse(" bug ,  , perf "));
+	}
+
+	@Test
+	public void testParseDeduplicatesCaseInsensitivelyKeepingFirst() {
+		assertEquals(List.of("Bug", "perf"), Tags.parse("Bug, bug, perf, PERF"));
+	}
+
+	@Test
+	public void testParseNullOrBlankIsEmpty() {
+		assertTrue(Tags.parse(null).isEmpty());
+		assertTrue(Tags.parse("   ").isEmpty());
+	}
+
+	@Test
+	public void testFormatSortsCaseInsensitivelyAndDeduplicates() {
+		// case-insensitive sort + dedup; first-seen casing wins ("PERF" before "perf")
+		assertEquals("bug,PERF,zebra", Tags.format(List.of("zebra", "bug", "PERF", "perf")));
+	}
+
+	@Test
+	public void testFormatEmptyReturnsNull() {
+		assertNull(Tags.format(List.of()));
+		assertNull(Tags.format(List.of("  ")));
+	}
+
+	@Test
+	public void testAddTag() {
+		assertEquals("bug,perf", Tags.addTag("perf", "bug"));
+		// already present (case-insensitive) -> no-op
+		assertEquals("perf", Tags.addTag("perf", "PERF"));
+		assertEquals("bug", Tags.addTag(null, "bug"));
+	}
+
+	@Test
+	public void testRemoveTag() {
+		assertEquals("perf", Tags.removeTag("bug,perf", "BUG"));
+		assertNull(Tags.removeTag("bug", "bug"));
+		assertEquals("perf", Tags.removeTag("perf", "absent"));
+	}
+
+	@Test
+	public void testGetTags() {
+		Bookmark bookmark = new Bookmark(new BookmarkId("b"), Map.of(PROP_TAGS, "bug, perf"));
+		assertEquals(List.of("bug", "perf"), Tags.getTags(bookmark));
+		assertTrue(Tags.getTags(new Bookmark(new BookmarkId("b2"))).isEmpty());
+	}
+
+	@Test
+	public void testHasTagMatching() {
+		Bookmark bookmark = new Bookmark(new BookmarkId("b"), Map.of(PROP_TAGS, "bug,performance"));
+		assertTrue(Tags.hasTagMatching(bookmark, "perf"));
+		assertTrue(Tags.hasTagMatching(bookmark, "BUG"));
+		assertFalse(Tags.hasTagMatching(bookmark, "zebra"));
+		// blank term matches any tagged bookmark
+		assertTrue(Tags.hasTagMatching(bookmark, ""));
+		assertFalse(Tags.hasTagMatching(new Bookmark(new BookmarkId("b2")), ""));
+	}
+
+	@Test
+	public void testExtractTagQuery() {
+		assertEquals("bug", Tags.extractTagQuery("tag:bug"));
+		assertEquals("bug", Tags.extractTagQuery("TAG: Bug "));
+		assertEquals("bug", Tags.extractTagQuery("#bug"));
+		assertNull(Tags.extractTagQuery("bug"));
+		assertNull(Tags.extractTagQuery(null));
+	}
+
+	@Test
+	public void testCollectAllTags() {
+		BookmarksTree tree = bookmarksTree("root")
+				.addBookmarks("root",
+						bookmark(new BookmarkId("b1"), "b1").withProperty(PROP_TAGS, "bug, perf"),
+						bookmark(new BookmarkId("b2"), "b2").withProperty(PROP_TAGS, "Perf, ui"),
+						bookmark(new BookmarkId("b3"), "b3"))
+				.build();
+		SortedSet<String> allTags = Tags.collectAllTags(tree);
+		assertEquals(List.of("bug", "perf", "ui"), List.copyOf(allTags));
+	}
+}


### PR DESCRIPTION
## Tags for bookmarks

Adds a transverse **tags** classification on top of the existing folder hierarchy: a bookmark can carry several tags (`bug`, `perf`, …) and be found/filtered by tag independently of where it lives in the tree.

### What's included
- **Storage** — tags live in a single `tags` bookmark property (comma-separated, normalized to lower case). New `mesfavoris.tags` package: `TagsBookmarkProperties` + pure `Tags` helpers.
- **MCP** — the `tags` property is declared `updatable`, so `modify_bookmark` sets tags and they appear in tool output (no new tool).
- **Detail panel** — a `Tags` tab: comma-separated field (applied live while typing) + a checklist of existing tags (check/uncheck to add/remove). Leaf bookmarks only.
- **Tree** — tags rendered as small discreet grey outlined pills next to the bookmark name.
- **Search** — `tag:xxx` / `#xxx` syntax (tags only) plus free-text also matches tags, in both the tool-window filter and Search Everywhere.
- **Virtual folder** — a `Tags` root grouping with one sub-folder per tag (required extending the virtual-folder model to support nested virtual folders).
- **`TagsIndex` service** — a project-level incremental index (`tag -> bookmark ids`) updated from `BookmarksModification` events, so tag lookups stay cheap with thousands of bookmarks instead of scanning the whole tree.

### Tests
119 tests: `TagsTest`, `TagsIndexTest`, `TagsVirtualFolderTest`, `BookmarksTreeFilterTest`, `TagsBookmarkDetailPartTest`, plus MCP coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
